### PR TITLE
Use git submodules for upstream repository packages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "upstream"]
+	path = upstream
+	url = https://github.com/kisslinux/repo.git
+	branch = master

--- a/core/baseinit
+++ b/core/baseinit
@@ -1,0 +1,1 @@
+../upstream/core/baseinit

--- a/core/baselayout/baselayout
+++ b/core/baselayout/baselayout
@@ -1,0 +1,1 @@
+../upstream/core/baselayout

--- a/core/binutils
+++ b/core/binutils
@@ -1,0 +1,1 @@
+../upstream/core/binutils

--- a/core/bison
+++ b/core/bison
@@ -1,0 +1,1 @@
+../upstream/core/bison

--- a/core/busybox/busybox
+++ b/core/busybox/busybox
@@ -1,0 +1,1 @@
+../upstream/core/busybox

--- a/core/bzip2
+++ b/core/bzip2
@@ -1,0 +1,1 @@
+../upstream/core/bzip2

--- a/core/curl
+++ b/core/curl
@@ -1,0 +1,1 @@
+../upstream/core/curl

--- a/core/flex
+++ b/core/flex
@@ -1,0 +1,1 @@
+../upstream/core/flex

--- a/core/gcc/gcc
+++ b/core/gcc/gcc
@@ -1,0 +1,1 @@
+../upstream/core/gcc

--- a/core/git
+++ b/core/git
@@ -1,0 +1,1 @@
+../upstream/core/git

--- a/core/grub
+++ b/core/grub
@@ -1,0 +1,1 @@
+../upstream/core/grub

--- a/core/gzip
+++ b/core/gzip
@@ -1,0 +1,1 @@
+../upstream/core/gzip

--- a/core/kiss
+++ b/core/kiss
@@ -1,0 +1,1 @@
+../upstream/core/kiss

--- a/core/libressl
+++ b/core/libressl
@@ -1,0 +1,1 @@
+../upstream/core/libressl

--- a/core/linux-headers
+++ b/core/linux-headers
@@ -1,0 +1,1 @@
+../upstream/core/linux-headers

--- a/core/m4
+++ b/core/m4
@@ -1,0 +1,1 @@
+../upstream/core/m4

--- a/core/make
+++ b/core/make
@@ -1,0 +1,1 @@
+../upstream/core/make

--- a/core/musl/musl
+++ b/core/musl/musl
@@ -1,0 +1,1 @@
+../upstream/core/musl

--- a/core/xz
+++ b/core/xz
@@ -1,0 +1,1 @@
+../upstream/core/xz

--- a/core/zlib
+++ b/core/zlib
@@ -1,0 +1,1 @@
+../upstream/core/zlib

--- a/extra/acpid
+++ b/extra/acpid
@@ -1,0 +1,1 @@
+../upstream/extra/acpid

--- a/extra/alsa-lib
+++ b/extra/alsa-lib
@@ -1,0 +1,1 @@
+../upstream/extra/alsa-lib

--- a/extra/alsa-utils
+++ b/extra/alsa-utils
@@ -1,0 +1,1 @@
+../upstream/extra/alsa-utils

--- a/extra/atk
+++ b/extra/atk
@@ -1,0 +1,1 @@
+../upstream/extra/atk

--- a/extra/cairo
+++ b/extra/cairo
@@ -1,0 +1,1 @@
+../upstream/extra/cairo

--- a/extra/cbindgen
+++ b/extra/cbindgen
@@ -1,0 +1,1 @@
+../upstream/extra/cbindgen

--- a/extra/ccache
+++ b/extra/ccache
@@ -1,0 +1,1 @@
+../upstream/extra/ccache

--- a/extra/clang
+++ b/extra/clang
@@ -1,0 +1,1 @@
+../upstream/extra/clang

--- a/extra/cmake
+++ b/extra/cmake
@@ -1,0 +1,1 @@
+../upstream/extra/cmake

--- a/extra/dhcpcd
+++ b/extra/dhcpcd
@@ -1,0 +1,1 @@
+../upstream/extra/dhcpcd

--- a/extra/dosfstools
+++ b/extra/dosfstools
@@ -1,0 +1,1 @@
+../upstream/extra/dosfstools

--- a/extra/e2fsprogs
+++ b/extra/e2fsprogs
@@ -1,0 +1,1 @@
+../upstream/extra/e2fsprogs

--- a/extra/efibootmgr
+++ b/extra/efibootmgr
@@ -1,0 +1,1 @@
+../upstream/extra/efibootmgr

--- a/extra/efivar
+++ b/extra/efivar
@@ -1,0 +1,1 @@
+../upstream/extra/efivar

--- a/extra/eiwd
+++ b/extra/eiwd
@@ -1,0 +1,1 @@
+../upstream/extra/eiwd

--- a/extra/eudev
+++ b/extra/eudev
@@ -1,0 +1,1 @@
+../upstream/extra/eudev

--- a/extra/expat
+++ b/extra/expat
@@ -1,0 +1,1 @@
+../upstream/extra/expat

--- a/extra/ffmpeg
+++ b/extra/ffmpeg
@@ -1,0 +1,1 @@
+../upstream/extra/ffmpeg

--- a/extra/firefox
+++ b/extra/firefox
@@ -1,0 +1,1 @@
+../upstream/extra/firefox

--- a/extra/firefox-bin
+++ b/extra/firefox-bin
@@ -1,0 +1,1 @@
+../upstream/extra/firefox-bin

--- a/extra/firefox-esr
+++ b/extra/firefox-esr
@@ -1,0 +1,1 @@
+../upstream/extra/firefox-esr

--- a/extra/firefox-esr-bin
+++ b/extra/firefox-esr-bin
@@ -1,0 +1,1 @@
+../upstream/extra/firefox-esr-bin

--- a/extra/firefox-privacy
+++ b/extra/firefox-privacy
@@ -1,0 +1,1 @@
+../upstream/extra/firefox-privacy

--- a/extra/fontconfig
+++ b/extra/fontconfig
@@ -1,0 +1,1 @@
+../upstream/extra/fontconfig

--- a/extra/freetype-harfbuzz
+++ b/extra/freetype-harfbuzz
@@ -1,0 +1,1 @@
+../upstream/extra/freetype-harfbuzz

--- a/extra/fribidi
+++ b/extra/fribidi
@@ -1,0 +1,1 @@
+../upstream/extra/fribidi

--- a/extra/gcompat
+++ b/extra/gcompat
@@ -1,0 +1,1 @@
+../upstream/extra/gcompat

--- a/extra/gdk-pixbuf
+++ b/extra/gdk-pixbuf
@@ -1,0 +1,1 @@
+../upstream/extra/gdk-pixbuf

--- a/extra/giflib
+++ b/extra/giflib
@@ -1,0 +1,1 @@
+../upstream/extra/giflib

--- a/extra/glib
+++ b/extra/glib
@@ -1,0 +1,1 @@
+../upstream/extra/glib

--- a/extra/gnupg1/gnupg1
+++ b/extra/gnupg1/gnupg1
@@ -1,0 +1,1 @@
+../upstream/extra/gnupg1

--- a/extra/gperf
+++ b/extra/gperf
@@ -1,0 +1,1 @@
+../upstream/extra/gperf

--- a/extra/gtk+2
+++ b/extra/gtk+2
@@ -1,0 +1,1 @@
+../upstream/extra/gtk+2

--- a/extra/gtk+3
+++ b/extra/gtk+3
@@ -1,0 +1,1 @@
+../upstream/extra/gtk+3

--- a/extra/hicolor-icon-theme
+++ b/extra/hicolor-icon-theme
@@ -1,0 +1,1 @@
+../upstream/extra/hicolor-icon-theme

--- a/extra/intel-vaapi-driver
+++ b/extra/intel-vaapi-driver
@@ -1,0 +1,1 @@
+../upstream/extra/intel-vaapi-driver

--- a/extra/lame
+++ b/extra/lame
@@ -1,0 +1,1 @@
+../upstream/extra/lame

--- a/extra/libass
+++ b/extra/libass
@@ -1,0 +1,1 @@
+../upstream/extra/libass

--- a/extra/libdrm
+++ b/extra/libdrm
@@ -1,0 +1,1 @@
+../upstream/extra/libdrm

--- a/extra/libelf
+++ b/extra/libelf
@@ -1,0 +1,1 @@
+../upstream/extra/libelf

--- a/extra/libepoxy
+++ b/extra/libepoxy
@@ -1,0 +1,1 @@
+../upstream/extra/libepoxy

--- a/extra/liberation-fonts
+++ b/extra/liberation-fonts
@@ -1,0 +1,1 @@
+../upstream/extra/liberation-fonts

--- a/extra/libevdev
+++ b/extra/libevdev
@@ -1,0 +1,1 @@
+../upstream/extra/libevdev

--- a/extra/libffi
+++ b/extra/libffi
@@ -1,0 +1,1 @@
+../upstream/extra/libffi

--- a/extra/libinput
+++ b/extra/libinput
@@ -1,0 +1,1 @@
+../upstream/extra/libinput

--- a/extra/libjpeg-turbo
+++ b/extra/libjpeg-turbo
@@ -1,0 +1,1 @@
+../upstream/extra/libjpeg-turbo

--- a/extra/libogg
+++ b/extra/libogg
@@ -1,0 +1,1 @@
+../upstream/extra/libogg

--- a/extra/libpng
+++ b/extra/libpng
@@ -1,0 +1,1 @@
+../upstream/extra/libpng

--- a/extra/libtheora
+++ b/extra/libtheora
@@ -1,0 +1,1 @@
+../upstream/extra/libtheora

--- a/extra/libudev-zero
+++ b/extra/libudev-zero
@@ -1,0 +1,1 @@
+../upstream/extra/libudev-zero

--- a/extra/libva
+++ b/extra/libva
@@ -1,0 +1,1 @@
+../upstream/extra/libva

--- a/extra/libva-utils
+++ b/extra/libva-utils
@@ -1,0 +1,1 @@
+../upstream/extra/libva-utils

--- a/extra/libvorbis
+++ b/extra/libvorbis
@@ -1,0 +1,1 @@
+../upstream/extra/libvorbis

--- a/extra/libvpx
+++ b/extra/libvpx
@@ -1,0 +1,1 @@
+../upstream/extra/libvpx

--- a/extra/libwebp
+++ b/extra/libwebp
@@ -1,0 +1,1 @@
+../upstream/extra/libwebp

--- a/extra/llvm
+++ b/extra/llvm
@@ -1,0 +1,1 @@
+../upstream/extra/llvm

--- a/extra/mandoc
+++ b/extra/mandoc
@@ -1,0 +1,1 @@
+../upstream/extra/mandoc

--- a/extra/mesa
+++ b/extra/mesa
@@ -1,0 +1,1 @@
+../upstream/extra/mesa

--- a/extra/meson
+++ b/extra/meson
@@ -1,0 +1,1 @@
+../upstream/extra/meson

--- a/extra/mpv
+++ b/extra/mpv
@@ -1,0 +1,1 @@
+../upstream/extra/mpv

--- a/extra/mtdev
+++ b/extra/mtdev
@@ -1,0 +1,1 @@
+../upstream/extra/mtdev

--- a/extra/nasm
+++ b/extra/nasm
@@ -1,0 +1,1 @@
+../upstream/extra/nasm

--- a/extra/ncurses
+++ b/extra/ncurses
@@ -1,0 +1,1 @@
+../upstream/extra/ncurses

--- a/extra/nodejs
+++ b/extra/nodejs
@@ -1,0 +1,1 @@
+../upstream/extra/nodejs

--- a/extra/opendoas
+++ b/extra/opendoas
@@ -1,0 +1,1 @@
+../upstream/extra/opendoas

--- a/extra/openresolv
+++ b/extra/openresolv
@@ -1,0 +1,1 @@
+../upstream/extra/openresolv

--- a/extra/openssh
+++ b/extra/openssh
@@ -1,0 +1,1 @@
+../upstream/extra/openssh

--- a/extra/opus
+++ b/extra/opus
@@ -1,0 +1,1 @@
+../upstream/extra/opus

--- a/extra/pango
+++ b/extra/pango
@@ -1,0 +1,1 @@
+../upstream/extra/pango

--- a/extra/perl
+++ b/extra/perl
@@ -1,0 +1,1 @@
+../upstream/extra/perl

--- a/extra/pkgconf
+++ b/extra/pkgconf
@@ -1,0 +1,1 @@
+../upstream/extra/pkgconf

--- a/extra/plzip
+++ b/extra/plzip
@@ -1,0 +1,1 @@
+../upstream/extra/plzip

--- a/extra/python
+++ b/extra/python
@@ -1,0 +1,1 @@
+../upstream/extra/python

--- a/extra/rsync
+++ b/extra/rsync
@@ -1,0 +1,1 @@
+../upstream/extra/rsync

--- a/extra/rust/rust
+++ b/extra/rust/rust
@@ -1,0 +1,1 @@
+../upstream/extra/rust

--- a/extra/samurai
+++ b/extra/samurai
@@ -1,0 +1,1 @@
+../upstream/extra/samurai

--- a/extra/sqlite
+++ b/extra/sqlite
@@ -1,0 +1,1 @@
+../upstream/extra/sqlite

--- a/extra/sudo
+++ b/extra/sudo
@@ -1,0 +1,1 @@
+../upstream/extra/sudo

--- a/extra/tiff
+++ b/extra/tiff
@@ -1,0 +1,1 @@
+../upstream/extra/tiff

--- a/extra/tzdata
+++ b/extra/tzdata
@@ -1,0 +1,1 @@
+../upstream/extra/tzdata

--- a/extra/util-linux
+++ b/extra/util-linux
@@ -1,0 +1,1 @@
+../upstream/extra/util-linux

--- a/extra/vim
+++ b/extra/vim
@@ -1,0 +1,1 @@
+../upstream/extra/vim

--- a/extra/wpa_supplicant
+++ b/extra/wpa_supplicant
@@ -1,0 +1,1 @@
+../upstream/extra/wpa_supplicant

--- a/extra/x264
+++ b/extra/x264
@@ -1,0 +1,1 @@
+../upstream/extra/x264

--- a/extra/x265
+++ b/extra/x265
@@ -1,0 +1,1 @@
+../upstream/extra/x265

--- a/extra/xfsprogs
+++ b/extra/xfsprogs
@@ -1,0 +1,1 @@
+../upstream/extra/xfsprogs

--- a/extra/xvidcore
+++ b/extra/xvidcore
@@ -1,0 +1,1 @@
+../upstream/extra/xvidcore

--- a/extra/zip
+++ b/extra/zip
@@ -1,0 +1,1 @@
+../upstream/extra/zip

--- a/extra/zstd
+++ b/extra/zstd
@@ -1,0 +1,1 @@
+../upstream/extra/zstd

--- a/xorg/libICE
+++ b/xorg/libICE
@@ -1,0 +1,1 @@
+../upstream/xorg/libICE

--- a/xorg/libSM
+++ b/xorg/libSM
@@ -1,0 +1,1 @@
+../upstream/xorg/libSM

--- a/xorg/libX11
+++ b/xorg/libX11
@@ -1,0 +1,1 @@
+../upstream/xorg/libX11

--- a/xorg/libXScrnSaver
+++ b/xorg/libXScrnSaver
@@ -1,0 +1,1 @@
+../upstream/xorg/libXScrnSaver

--- a/xorg/libXau
+++ b/xorg/libXau
@@ -1,0 +1,1 @@
+../upstream/xorg/libXau

--- a/xorg/libXcomposite
+++ b/xorg/libXcomposite
@@ -1,0 +1,1 @@
+../upstream/xorg/libXcomposite

--- a/xorg/libXcursor
+++ b/xorg/libXcursor
@@ -1,0 +1,1 @@
+../upstream/xorg/libXcursor

--- a/xorg/libXdamage
+++ b/xorg/libXdamage
@@ -1,0 +1,1 @@
+../upstream/xorg/libXdamage

--- a/xorg/libXext
+++ b/xorg/libXext
@@ -1,0 +1,1 @@
+../upstream/xorg/libXext

--- a/xorg/libXfixes
+++ b/xorg/libXfixes
@@ -1,0 +1,1 @@
+../upstream/xorg/libXfixes

--- a/xorg/libXfont2
+++ b/xorg/libXfont2
@@ -1,0 +1,1 @@
+../upstream/xorg/libXfont2

--- a/xorg/libXft
+++ b/xorg/libXft
@@ -1,0 +1,1 @@
+../upstream/xorg/libXft

--- a/xorg/libXi
+++ b/xorg/libXi
@@ -1,0 +1,1 @@
+../upstream/xorg/libXi

--- a/xorg/libXinerama
+++ b/xorg/libXinerama
@@ -1,0 +1,1 @@
+../upstream/xorg/libXinerama

--- a/xorg/libXmu
+++ b/xorg/libXmu
@@ -1,0 +1,1 @@
+../upstream/xorg/libXmu

--- a/xorg/libXrandr
+++ b/xorg/libXrandr
@@ -1,0 +1,1 @@
+../upstream/xorg/libXrandr

--- a/xorg/libXrender
+++ b/xorg/libXrender
@@ -1,0 +1,1 @@
+../upstream/xorg/libXrender

--- a/xorg/libXt
+++ b/xorg/libXt
@@ -1,0 +1,1 @@
+../upstream/xorg/libXt

--- a/xorg/libXtst
+++ b/xorg/libXtst
@@ -1,0 +1,1 @@
+../upstream/xorg/libXtst

--- a/xorg/libXxf86vm
+++ b/xorg/libXxf86vm
@@ -1,0 +1,1 @@
+../upstream/xorg/libXxf86vm

--- a/xorg/libfontenc
+++ b/xorg/libfontenc
@@ -1,0 +1,1 @@
+../upstream/xorg/libfontenc

--- a/xorg/libpciaccess
+++ b/xorg/libpciaccess
@@ -1,0 +1,1 @@
+../upstream/xorg/libpciaccess

--- a/xorg/libxcb
+++ b/xorg/libxcb
@@ -1,0 +1,1 @@
+../upstream/xorg/libxcb

--- a/xorg/libxkbcommon
+++ b/xorg/libxkbcommon
@@ -1,0 +1,1 @@
+../upstream/xorg/libxkbcommon

--- a/xorg/libxkbfile
+++ b/xorg/libxkbfile
@@ -1,0 +1,1 @@
+../upstream/xorg/libxkbfile

--- a/xorg/libxshmfence
+++ b/xorg/libxshmfence
@@ -1,0 +1,1 @@
+../upstream/xorg/libxshmfence

--- a/xorg/pixman
+++ b/xorg/pixman
@@ -1,0 +1,1 @@
+../upstream/xorg/pixman

--- a/xorg/setxkbmap
+++ b/xorg/setxkbmap
@@ -1,0 +1,1 @@
+../upstream/xorg/setxkbmap

--- a/xorg/sowm
+++ b/xorg/sowm
@@ -1,0 +1,1 @@
+../upstream/xorg/sowm

--- a/xorg/st
+++ b/xorg/st
@@ -1,0 +1,1 @@
+../upstream/xorg/st

--- a/xorg/xauth
+++ b/xorg/xauth
@@ -1,0 +1,1 @@
+../upstream/xorg/xauth

--- a/xorg/xbitmaps
+++ b/xorg/xbitmaps
@@ -1,0 +1,1 @@
+../upstream/xorg/xbitmaps

--- a/xorg/xcb-proto
+++ b/xorg/xcb-proto
@@ -1,0 +1,1 @@
+../upstream/xorg/xcb-proto

--- a/xorg/xcb-util
+++ b/xorg/xcb-util
@@ -1,0 +1,1 @@
+../upstream/xorg/xcb-util

--- a/xorg/xcb-util-cursor
+++ b/xorg/xcb-util-cursor
@@ -1,0 +1,1 @@
+../upstream/xorg/xcb-util-cursor

--- a/xorg/xcb-util-image
+++ b/xorg/xcb-util-image
@@ -1,0 +1,1 @@
+../upstream/xorg/xcb-util-image

--- a/xorg/xcb-util-keysyms
+++ b/xorg/xcb-util-keysyms
@@ -1,0 +1,1 @@
+../upstream/xorg/xcb-util-keysyms

--- a/xorg/xcb-util-renderutil
+++ b/xorg/xcb-util-renderutil
@@ -1,0 +1,1 @@
+../upstream/xorg/xcb-util-renderutil

--- a/xorg/xcb-util-wm
+++ b/xorg/xcb-util-wm
@@ -1,0 +1,1 @@
+../upstream/xorg/xcb-util-wm

--- a/xorg/xev
+++ b/xorg/xev
@@ -1,0 +1,1 @@
+../upstream/xorg/xev

--- a/xorg/xf86-input-libinput
+++ b/xorg/xf86-input-libinput
@@ -1,0 +1,1 @@
+../upstream/xorg/xf86-input-libinput

--- a/xorg/xf86-video-amdgpu
+++ b/xorg/xf86-video-amdgpu
@@ -1,0 +1,1 @@
+../upstream/xorg/xf86-video-amdgpu

--- a/xorg/xf86-video-ati
+++ b/xorg/xf86-video-ati
@@ -1,0 +1,1 @@
+../upstream/xorg/xf86-video-ati

--- a/xorg/xf86-video-intel
+++ b/xorg/xf86-video-intel
@@ -1,0 +1,1 @@
+../upstream/xorg/xf86-video-intel

--- a/xorg/xf86-video-nouveau
+++ b/xorg/xf86-video-nouveau
@@ -1,0 +1,1 @@
+../upstream/xorg/xf86-video-nouveau

--- a/xorg/xf86-video-vesa
+++ b/xorg/xf86-video-vesa
@@ -1,0 +1,1 @@
+../upstream/xorg/xf86-video-vesa

--- a/xorg/xinit
+++ b/xorg/xinit
@@ -1,0 +1,1 @@
+../upstream/xorg/xinit

--- a/xorg/xinput
+++ b/xorg/xinput
@@ -1,0 +1,1 @@
+../upstream/xorg/xinput

--- a/xorg/xkbcomp
+++ b/xorg/xkbcomp
@@ -1,0 +1,1 @@
+../upstream/xorg/xkbcomp

--- a/xorg/xkeyboard-config
+++ b/xorg/xkeyboard-config
@@ -1,0 +1,1 @@
+../upstream/xorg/xkeyboard-config

--- a/xorg/xorg-server
+++ b/xorg/xorg-server
@@ -1,0 +1,1 @@
+../upstream/xorg/xorg-server

--- a/xorg/xorg-util-macros
+++ b/xorg/xorg-util-macros
@@ -1,0 +1,1 @@
+../upstream/xorg/xorg-util-macros

--- a/xorg/xorgproto
+++ b/xorg/xorgproto
@@ -1,0 +1,1 @@
+../upstream/xorg/xorgproto

--- a/xorg/xprop
+++ b/xorg/xprop
@@ -1,0 +1,1 @@
+../upstream/xorg/xprop

--- a/xorg/xrandr
+++ b/xorg/xrandr
@@ -1,0 +1,1 @@
+../upstream/xorg/xrandr

--- a/xorg/xrdb
+++ b/xorg/xrdb
@@ -1,0 +1,1 @@
+../upstream/xorg/xrdb

--- a/xorg/xset
+++ b/xorg/xset
@@ -1,0 +1,1 @@
+../upstream/xorg/xset

--- a/xorg/xsetroot
+++ b/xorg/xsetroot
@@ -1,0 +1,1 @@
+../upstream/xorg/xsetroot

--- a/xorg/xtrans
+++ b/xorg/xtrans
@@ -1,0 +1,1 @@
+../upstream/xorg/xtrans


### PR DESCRIPTION
Upstream [recommends](https://k1ss.org/news/20200811a) using git submodules for depending on other repositories, so we're trying that out.

One way we could implement this change is by moving all our current repository subdirectories to a directory called `repo32`, whereas upstream can sit in a directory called `repo`. Just so we can easily differentiate from which are the main packages and which are our forks.

However, that will likely break `KISS_PATH` for all previous installations, so we're not going to do that. Instead, I've added a new subdirectory called `upstream`. And that is where our upstream files will sit.

I feel this solution is less clean though, as we no longer have a clear directory structure of `[repo]/[subrepo]/[package]`. I suppose, keeping things working for our users is more important in this case. So we're sticking with the latter option.

If you disagree, discuss it with me in #4.